### PR TITLE
Fixing the strange behavior in program arguments.

### DIFF
--- a/LSTM_peptides.py
+++ b/LSTM_peptides.py
@@ -42,7 +42,7 @@ flags.add_argument("-l", "--layers", default=2, help="number of layers in the ne
 flags.add_argument("-x", "--neurons", default=256, help="number of units per layer", type=int)
 flags.add_argument("-c", "--cell", default="LSTM", help="type of neuron to use, available: LSTM, GRU", type=str)
 flags.add_argument("-o", "--dropout", default=0.1, help="dropout to use in every layer; layer 1 gets 1*dropout, layer 2 2*dropout etc.", type=float)
-flags.add_argument("-t", "--train", default=True, help="whether the network should be trained or just sampled from", type=bool)
+flags.add_argument("--mode", default='pretrain', help="whether the network should be pre-trained, fine-tuned, or just sampled.", type=str, choices=['pretrain', 'finetune', 'sample'])
 flags.add_argument("-v", "--valsplit", default=0.2, help="fraction of the data to use for validation", type=float)
 flags.add_argument("-s", "--sample", default=100, help="number of sequences to sample training", type=int)
 flags.add_argument("-p", "--temp", default=1.25, help="temperature used for sampling", type=float)
@@ -51,7 +51,6 @@ flags.add_argument("-a", "--startchar", default="B", help="starting character to
 flags.add_argument("-r", "--lr", default=0.01, help="learning rate to be used with the Adam optimizer", type=float)
 flags.add_argument("--l2", default=None, help="l2 regularization rate. If None, no l2 regularization is used", type=float)
 flags.add_argument("--modfile", default=None, help="filename of the pretrained model to used for sampling if train=False", type=str)
-flags.add_argument("--finetune", default=False, help="if True, a pretrained model provided in modfile is finetuned on the dataset", type=bool)
 flags.add_argument("--cv", default=None, help="number of folds to use for cross-validation; if None, no CV is performed", type=int)
 flags.add_argument("--window", default=0, help="window size used to process sequences. If 0, all sequences are padded to the longest sequence length in the dataset", type=int)
 flags.add_argument("--step", default=1, help="step size to move window or prediction target", type=int)
@@ -772,12 +771,15 @@ def main(infile, sessname, neurons=64, layers=2, epochs=100, batchsize=128, wind
 
 if __name__ == "__main__":
     # run main code
+    mode = args.mode
+    train = mode == 'pretrain'
+    finetune = mode == 'finetune'
     main(infile=args.dataset, sessname=args.name, batchsize=args.batch_size, epochs=args.epochs,
          layers=args.layers, valsplit=args.valsplit, neurons=args.neurons, cell=args.cell, sample=args.sample,
-         temperature=args.temp, dropout=args.dropout, train=args.train, modfile=args.modfile,
+         temperature=args.temp, dropout=args.dropout, train=train, modfile=args.modfile,
          learningrate=args.lr, cv=args.cv, samplelength=args.maxlen, window=args.window,
          step=args.step, aa=args.startchar, l2_rate=args.l2, target=args.target, pad=args.padlen,
-         finetune=args.finetune, references=args.refs)
+         finetune=finetune, references=args.refs)
     
     # save used flags to log file
     _save_flags("./" + args.name + "/flags.txt")

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install -r requirements.txt
 Finally run the model as follows (with your own parameters provided, see the list below):
 
 ``` bash
-python LSTM_peptides.py --dataset $TRAINING_DATA_FILE --name $YOUR_RUN_NAME  $FURTHER_OPTIONAL_PARAMETERS
+python LSTM_peptides.py --dataset $TRAINING_DATA_FILE --name $YOUR_RUN_NAME $FURTHER_OPTIONAL_PARAMETERS
 ```
 
 #### Parameters:
@@ -52,8 +52,8 @@ python LSTM_peptides.py --dataset $TRAINING_DATA_FILE --name $YOUR_RUN_NAME  $FU
 - `dropout` *(OPTIONAL, default=`0.1`)*
   - Fraction of dropout to apply to the network. This scales with depth, so layer1 gets 1\*dropout, Layer2 2\*dropout
    etc.
-- `train` *(OPTIONAL, default=`True`)*
-  - Whether to train the model (`True`) or just sample from a pre-trained model (`False`).
+- `mode` *(OPTIONAL, choices=\["pretrain". "finetune", "sample"\]. default="pretrain", )*
+  - Whether to pre-train (`"pretrain"`), fine-tune (`"finetune"`) or just sample from a pre-trained model (`"sample"`).
 - `valsplit` *(OPTIONAL, default=`0.2`)*
   - Fraction of the data to use for model validation. If 0, no validation is performed.
 - `sample` *(OPTIONAL, default=`100`)*
@@ -86,19 +86,19 @@ python LSTM_peptides.py --dataset $TRAINING_DATA_FILE --name $YOUR_RUN_NAME  $FU
   - whether reference sequence sets should be generated for the analysis
 
 
-### Example: training a 2-layer model with 64 neurons on new sequences for 100 epochs
+### Example: pre-training a 2-layer model with 64 neurons on new sequences for 100 epochs
 ``` bash
-python LSTM_peptides.py --name train100 --dataset new_sequences.csv --layers 2 --neurons 64 --epochs 100
+python LSTM_peptides.py --mode pretrain --name train100 --dataset new_sequences.csv --layers 2 --neurons 64 --epochs 100
 ```
 
 ### Example: sampling 100 sequences from a pre-trained model
 ``` bash
-python LSTM_peptides.py --name testsample --modfile pretrained_model/checkpoint/model_epoch_99.hdf5 --train False --sample 100
+python LSTM_peptides.py --mode sample --name testsample --modfile pretrained_model/checkpoint/model_epoch_99.hdf5 --sample 100
 ```
 
 ### Example: finetune a pre-trained model on a finetuning set for 10 epochs
 ``` bash
-python LSTM_peptides.py --name finetune10 --dataset finetune_set.csv --modfile pretrained_model/checkpoint/model_epoch_99.hdf5 --epochs 10--train False --finetune True
+python LSTM_peptides.py --mode finetune --name finetune10 --dataset finetune_set.csv --modfile pretrained_model/checkpoint/model_epoch_99.hdf5 --epochs 10
 ```
 
 ## Cite

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ python LSTM_peptides.py --dataset $TRAINING_DATA_FILE --name $YOUR_RUN_NAME $FUR
 - `dropout` *(OPTIONAL, default=`0.1`)*
   - Fraction of dropout to apply to the network. This scales with depth, so layer1 gets 1\*dropout, Layer2 2\*dropout
    etc.
-- `mode` *(OPTIONAL, choices=\["pretrain". "finetune", "sample"\]. default="pretrain", )*
-  - Whether to pre-train (`"pretrain"`), fine-tune (`"finetune"`) or just sample from a pre-trained model (`"sample"`).
+- `mode` *(OPTIONAL, choices=\[pretrain. finetune, sample\]. default=pretrain)*
+  - Whether to pre-train (`pretrain`), fine-tune (`finetune`) or just sample from a pre-trained model (`sample`).
 - `valsplit` *(OPTIONAL, default=`0.2`)*
   - Fraction of the data to use for model validation. If 0, no validation is performed.
 - `sample` *(OPTIONAL, default=`100`)*

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ python LSTM_peptides.py --dataset $TRAINING_DATA_FILE --name $YOUR_RUN_NAME $FUR
 - `dropout` *(OPTIONAL, default=`0.1`)*
   - Fraction of dropout to apply to the network. This scales with depth, so layer1 gets 1\*dropout, Layer2 2\*dropout
    etc.
-- `mode` *(OPTIONAL, choices=\[pretrain. finetune, sample\]. default=pretrain)*
+- `mode` *(OPTIONAL, choices=\[pretrain. finetune, sample\], default=pretrain)*
   - Whether to pre-train (`pretrain`), fine-tune (`finetune`) or just sample from a pre-trained model (`sample`).
 - `valsplit` *(OPTIONAL, default=`0.2`)*
   - Fraction of the data to use for model validation. If 0, no validation is performed.


### PR DESCRIPTION
Remove (supposed-to-be) boolean `train` and `finetune` arguments and created a `mode` argument. The new argument can take `pretrain`, `finetune`, and `sample` values to select between program modes. Minimum changes to the code was made. README is also changed accordingly.